### PR TITLE
Make MicroShift version a variable and default to V4.13 in rpm role

### DIFF
--- a/roles/rpm_install/README.md
+++ b/roles/rpm_install/README.md
@@ -22,6 +22,13 @@ Example:
 rpm_install_pull_secret: "{{ lookup('file', '~/Downloads/pull-secret.txt') }}"
 ```
 
+## rpm_install_version
+Type: string
+Required: false
+Default: 4.13
+MicroShift version to install, in semver format. Major.Minor will determine which repos are enabled.
+
+
 Dependencies
 ------------
 

--- a/roles/rpm_install/README.md
+++ b/roles/rpm_install/README.md
@@ -26,7 +26,10 @@ rpm_install_pull_secret: "{{ lookup('file', '~/Downloads/pull-secret.txt') }}"
 Type: string
 Required: false
 Default: 4.13
-MicroShift version to install, in semver format. Major.Minor will determine which repos are enabled.
+MicroShift version to install, in semver format. Major.Minor will determine which repos are enabled.If no patch version is given, latest patch will be installed.
+```yaml
+rpm_install_version: 4.13
+```
 
 
 Dependencies

--- a/roles/rpm_install/tasks/main.yml
+++ b/roles/rpm_install/tasks/main.yml
@@ -13,17 +13,17 @@
         name:
           - "rhel-{{ ansible_distribution_major_version }}-for-x86_64-appstream-rpms"
           - "rhel-{{ ansible_distribution_major_version }}-for-x86_64-baseos-rpms"
-          - "rhocp-{{ rpm_install_version.split('.')[0]}}.{{ rpm_install_version.split('.')[1]}}-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
+          - "rhocp-{{ rpm_install_version.split('.')[0] }}.{{ rpm_install_version.split('.')[1] }}-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms" # noqa: yaml[line-length]
           - "fast-datapath-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
       when:
         - ansible_distribution == 'RedHat'
 
-    - name: Install MicroShift V{{ rpm_install_version}} and openshift-clients
+    - name: Install openshift-clients and MicroShift V{{ rpm_install_version }}
       ansible.builtin.dnf:
         name: "{{ item }}"
         state: present
       loop:
-        - microshift-{{ rpm_install_version}}
+        - microshift-{{ rpm_install_version }}
         - openshift-clients
 
     - name: Copy pull secret

--- a/roles/rpm_install/tasks/main.yml
+++ b/roles/rpm_install/tasks/main.yml
@@ -13,17 +13,17 @@
         name:
           - "rhel-{{ ansible_distribution_major_version }}-for-x86_64-appstream-rpms"
           - "rhel-{{ ansible_distribution_major_version }}-for-x86_64-baseos-rpms"
-          - "rhocp-4.12-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
+          - "rhocp-{{ rpm_install_version.split('.')[0]}}.{{ rpm_install_version.split('.')[1]}}-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
           - "fast-datapath-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
       when:
         - ansible_distribution == 'RedHat'
 
-    - name: Install the latest version of Microshift and openshift-clients
+    - name: Install MicroShift V{{ rpm_install_version}} and openshift-clients
       ansible.builtin.dnf:
         name: "{{ item }}"
         state: present
       loop:
-        - microshift
+        - microshift-{{ rpm_install_version}}
         - openshift-clients
 
     - name: Copy pull secret

--- a/roles/rpm_install/vars/main.yml
+++ b/roles/rpm_install/vars/main.yml
@@ -1,1 +1,2 @@
 ---
+rpm_install_version: 4.13


### PR DESCRIPTION
# Description
Remove hardcoded version numer in rpm install 

FIXES: #58 at least partially

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [x] Refactor

## Checklist

- [ ] Added changelog fragment
- [ ] Tests exist for affected features covering positive and negative scenarios